### PR TITLE
Update XKCD Link

### DIFF
--- a/Week1/MAKEME.md
+++ b/Week1/MAKEME.md
@@ -32,10 +32,10 @@ Write a function that makes an API call to `https://www.randomuser.me/api`
 
 Who knew programmers could be funny?
 
-Write an function that makes an API call to `https://xkcd.com/info.0.json`
+Write an function that makes an API call to `https://xkcd.now.sh/?comic=latest`
 
 - Inside the same file write two programs: one with `XMLHttpRequest`, and the other with `axios`
-- Each function should make an API call to the given endpoint: `https://xkcd.com/info.0.json`
+- Each function should make an API call to the given endpoint: `https://xkcd.now.sh/?comic=latest`
 - Log the received data to the console
 - Render the `img` property into an `<img>` tag in the DOM
 - Incorporate error handling


### PR DESCRIPTION
The old link now requires CORS to work with it which is an unusual stumbling block for working with a public API.

You can use this one instead:
https://xkcd.now.sh/?comic=latest